### PR TITLE
Preserve token content

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -188,6 +188,7 @@ function image_with_size(md, options) {
       }
 
       token          = state.push('image', 'img', 0);
+      token.content  = state.src.slice(labelStart, labelEnd);
       token.attrs    = attrs = [ [ 'src', href ],
                                  [ 'alt', '' ] ];
       token.children = tokens;

--- a/test/test.js
+++ b/test/test.js
@@ -23,6 +23,27 @@ describe('markdown-it-imsize (autofill)', function() {
   generate(path.join(__dirname, 'fixtures/markdown-it-imsize/autofill.txt'), md);
 });
 
+describe('markdown-it-imsize (chained)', function() {
+  var md = require('markdown-it')({
+    html: true,
+    linkify: true,
+    typography: true
+  }).use(
+    require('../lib')
+  ).use(
+    function(md, config) {
+      md.renderer.rules.image = function (tokens, idx, _options, _env, _self) {
+        var token = tokens[idx];
+        assert.equal(token.content, 'test alt value')
+      }
+    }
+  );
+
+  it('preserves token content', function() {
+    md.render('![test alt value](https://image.com/image.png)')
+  });
+});
+
 describe('image size detector', function() {
   var imsize = require('../lib/imsize');
   var types = require('../lib/imsize/types');


### PR DESCRIPTION
This is a small change that preserves the `token.content`, so that it can be used by other image-related markdown-it plugins. This allows for compatibility between this plugin and [markdown-it-linkify-images](https://github.com/crookedneighbor/markdown-it-linkify-images). Here's the related PR: https://github.com/crookedneighbor/markdown-it-linkify-images/pull/43